### PR TITLE
Use POSTGRES_USER and POSTGRES_PASSWORD env variables

### DIFF
--- a/taiga-back/README.md
+++ b/taiga-back/README.md
@@ -98,3 +98,9 @@ Email configuration:
 * ``EMAIL_HOST_USER`` defaults to ``""``
 * ``EMAIL_HOST_PASSWORD`` defaults to ``""``
 * ``DEFAULT_FROM_EMAIL`` defaults to ``"no-reply@example.com"``
+
+Database configuration:
+
+* ``POSTGRES_NAME``. Use to override database name.
+* ``POSTGRES_USER``. Use to override user specified in linked postgres container.
+* ``POSTGRES_PASSWORD``. Use to override password specified in linked postgres container.

--- a/taiga-back/configure
+++ b/taiga-back/configure
@@ -24,9 +24,9 @@ from .common import *
 DATABASES = {
    'default': {
        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
-       'NAME': '${POSTGRES_ENV_POSTGRES_USER}',
-       'USER': '${POSTGRES_ENV_POSTGRES_USER}',
-       'PASSWORD': '${POSTGRES_ENV_POSTGRES_PASSWORD}',
+       'NAME': '${POSTGRES_NAME:-$POSTGRES_ENV_POSTGRES_USER}',
+       'USER': '${POSTGRES_USER:-$POSTGRES_ENV_POSTGRES_USER}',
+       'PASSWORD': '${POSTGRES_PASSWORD:-$POSTGRES_ENV_POSTGRES_PASSWORD}',
        'HOST': '${POSTGRES_PORT_5432_TCP_ADDR}',
        'PORT': '5432',
    }


### PR DESCRIPTION
Allow user to override database parameters using POSTGRES_USER and POSTGRES_PASSWORD environment variables instead default ones provided by linked postgres container.
