### PR TITLE
Update DB backend for Taiga 2.0.0

### DIFF
--- a/taiga-back/configure
+++ b/taiga-back/configure
@@ -27,7 +27,7 @@ from .common import *
 
 DATABASES = {
    'default': {
-       'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
+       'ENGINE': 'django.db.backends.postgresql',
        'NAME': '${POSTGRES_DB_NAME}',
        'USER': '${POSTGRES_USER}',
        'PASSWORD': '${POSTGRES_PASSWORD}',

--- a/taiga-front-dist/configure
+++ b/taiga-front-dist/configure
@@ -19,7 +19,7 @@ mkdir -p /etc/nginx/ssl
 PUBLIC_REGISTER_ENABLED=${PUBLIC_REGISTER_ENABLED:-true}
 API=${API:-/api/v1/}
 
-cat > /usr/local/taiga/taiga-front-dist/dist/js/conf.json <<EOL
+cat > /usr/local/taiga/taiga-front-dist/dist/conf.json <<EOL
 
 {
   "api": "${API}",


### PR DESCRIPTION
As described [here](http://taigaio.github.io/taiga-doc/dist/upgrades.html#_1_10_0_2_0_0), the required database backend settings changed in Taiga 2.0.0.
