### PR TITLE
added script to add default user and password

### DIFF
--- a/taiga-back/start
+++ b/taiga-back/start
@@ -12,6 +12,9 @@ while ! nc -z $POSTGRES_PORT_5432_TCP_ADDR 5432; do
 done
 
 python manage.py migrate --noinput
+python manage.py loaddata initial_user
+python manage.py loaddata initial_project_templates
+python manage.py loaddata initial_role
 
 chown -R taiga /usr/local/taiga/media /usr/local/taiga/static /usr/local/taiga/logs
 


### PR DESCRIPTION
When the container is up and running, there is no way for the user to login. I've added the script to create default user and password

username: admin
password: 123123

check this issue for details
https://github.com/taigaio/taiga-scripts/issues/24 
